### PR TITLE
include unordered map

### DIFF
--- a/src/util/io/reader.hpp
+++ b/src/util/io/reader.hpp
@@ -10,6 +10,7 @@
 
 #include <util/prec.hpp>
 #include <util/version.hpp>
+#include <unordered_map>
 
 template <typename T> class Defaultable;
 template <typename T> class Scriptable;

--- a/src/util/io/writer.hpp
+++ b/src/util/io/writer.hpp
@@ -10,6 +10,7 @@
 
 #include <util/prec.hpp>
 #include <wx/txtstrm.h>
+#include <unordered_map>
 
 template <typename T> class Defaultable;
 template <typename T> class Scriptable;


### PR DESCRIPTION
Add unordered_map include directives to src/util/io/reader.hpp and ./writer.hpp to prevent an early compile-time error on Mac OS 10.14 “Mojave”.