### PR TITLE
Improvements to built-in vcs integration

### DIFF
--- a/src/util/io/package.cpp
+++ b/src/util/io/package.cpp
@@ -425,6 +425,10 @@ void Package::saveToDirectory(const String& saveAs, bool remove_unused, bool is_
         vcs->addFile(f_out_path);
         f.second.created = false;
       }
+      else
+      {
+          vcs->updateFile(f_out_path);
+      }
     } else if (filename != saveAs) {
       // save as, copy old filess
       if (isZipfile()) {

--- a/src/util/vcs.cpp
+++ b/src/util/vcs.cpp
@@ -9,6 +9,7 @@
 #include <util/prec.hpp>
 #include <util/vcs.hpp>
 #include <util/vcs/subversion.hpp>
+#include <util/vcs/git.hpp>
 
 // ----------------------------------------------------------------------------- : Reflection
 
@@ -19,6 +20,7 @@ VCSP read_new<VCS>(Reader& reader) {
   reader.handle(_("type"), type);
   if      (type == _("none")) return make_intrusive<VCS>();
   else if (type == _("subversion")) return make_intrusive<SubversionVCS>();
+  else if (type == _("git")) return make_intrusive<GitVCS>();
   else if (type.empty()) {
     reader.warning(_ERROR_1_("expected key", _("version control system")));
     throw ParseError(_ERROR_("aborting parsing"));

--- a/src/util/vcs.hpp
+++ b/src/util/vcs.hpp
@@ -41,6 +41,9 @@ public:
   virtual void removeFile (const wxFileName& filename) {
     remove_file(filename.GetFullName());
   }
+  /// Mark a file as updated
+  virtual void updateFile(const wxFileName& filename) {
+  }
   
   DECLARE_REFLECTION_VIRTUAL();
 };

--- a/src/util/vcs/git.cpp
+++ b/src/util/vcs/git.cpp
@@ -1,0 +1,97 @@
+//+----------------------------------------------------------------------------+
+//| Description:  Magic Set Editor - Program to make Magic (tm) cards          |
+//| Copyright:    (C) Twan van Laarhoven and the other MSE developers          |
+//| License:      GNU General Public License 2 or later (see file COPYING)     |
+//+----------------------------------------------------------------------------+
+
+// ----------------------------------------------------------------------------- : Includes
+
+#include <util/prec.hpp>
+#include <util/vcs/git.hpp>
+#include "wx/process.h"
+
+// ----------------------------------------------------------------------------- : SVN File Manipulation
+
+bool run_git(const Char** arguments, const wxString wd) {
+    wxProcess* process = new wxProcess(wxPROCESS_REDIRECT);
+    process->Redirect();
+    wxExecuteEnv* env = new wxExecuteEnv();
+    env->cwd = wd;
+    switch (wxExecute(const_cast<Char**>(arguments), wxEXEC_SYNC, process, env)) { // Yuck, const_cast
+    // Success
+    case 0:
+        delete process;
+        delete env;
+        return true;
+    // Couldn't run Git
+    case -1:
+        handle_error(String(_("Can't run Git.")));
+        delete process;
+        delete env;
+        return false;
+    // Git error
+    default:
+        String error = String(_("Git encountered an error:\n"));
+        wxString log;
+        wxInputStream* err = process->GetErrorStream();
+
+        wxTextInputStream tStream(*err);
+        while (!err->Eof())
+        {
+            log = tStream.ReadLine();
+            error.append(log).append('\n');
+        }
+        handle_error(error);
+        delete process;
+        delete env;
+        return false;
+    }
+
+}
+
+void GitVCS::addFile(const wxFileName& filename)
+{
+    String name = filename.GetFullPath();
+    wxString wd = filename.GetPath(true);
+    const Char* name_c[] = { _("git"), _("add"), name.c_str(), nullptr };
+    if (!run_git(name_c, wd)) {
+        VCS::addFile(filename);
+    }
+}
+
+void GitVCS::moveFile(const wxFileName& source, const wxFileName& dest)
+{
+    String source_name = source.GetFullPath(), dest_name = dest.GetFullPath();
+    const Char* name_c[] = { _("git"), _("mv"), source_name.c_str(), dest_name.c_str(), nullptr };
+    wxString wd = source.GetPath(true);
+    if (!run_git(name_c, wd)) {
+        VCS::moveFile(source, dest);
+    }
+}
+
+void GitVCS::removeFile(const wxFileName& filename)
+{
+    String name = filename.GetFullPath();
+    const Char* name_c[] = { _("git"), _("rm"), name.c_str(), nullptr };
+    wxString wd = filename.GetPath(true);
+    queue_message(MESSAGE_WARNING, String(name_c[0]) + name_c[1] + name_c[2]);
+    // `git rm` only removes it from the index.  We still need to removed it from the filesystem.
+    VCS::removeFile(filename);
+    if (!run_git(name_c, wd)) {
+        VCS::removeFile(filename);
+    }
+}
+
+void GitVCS::updateFile(const wxFileName& filename) {
+    // Git needs you to explicitly stage changes
+    this->addFile(filename);
+}
+
+IMPLEMENT_REFLECTION(GitVCS) {
+    REFLECT_IF_NOT_READING{
+      String type = _("git");
+      REFLECT(type);
+    }
+}
+
+// ----------------------------------------------------------------------------- : EOF

--- a/src/util/vcs/git.hpp
+++ b/src/util/vcs/git.hpp
@@ -1,0 +1,25 @@
+//+----------------------------------------------------------------------------+
+//| Description:  Magic Set Editor - Program to make Magic (tm) cards          |
+//| Copyright:    (C) Twan van Laarhoven and the other MSE developers          |
+//| License:      GNU General Public License 2 or later (see file COPYING)     |
+//+----------------------------------------------------------------------------+
+
+#pragma once
+
+// ----------------------------------------------------------------------------- : Includes
+
+#include <util/prec.hpp>
+#include <util/vcs.hpp>
+
+// ----------------------------------------------------------------------------- : SubversionVCS
+
+class GitVCS : public VCS {
+public:
+	void addFile(const wxFileName& filename) final;
+	void moveFile(const wxFileName& source, const wxFileName& destination) final;
+	void removeFile(const wxFileName& filename) final;
+	void updateFile(const wxFileName& filename) final;
+
+	DECLARE_REFLECTION();
+};
+


### PR DESCRIPTION
MSE has VCS support.  But it sucks.

My intent with this PR is to overhaul it a bit:
- [x] Add Git support alongside svn.
- [ ] Automatically commit, rather than just staging changes.
- [ ] Pull when loading a set (This might not be possible, we'll see)
- [ ] Automatically detect if a set is under version control, rather than having a property in `set`.