### PR TITLE
Fix mac installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ cmake --build build
 ````
 Use `CMAKE_BUILD_TYPE=Debug` for a debug build
 
-## Building on Mac
+## Building on Mac (Doesn't support M1 Macs)
 
 Install the dependencies, for example using Homebrew
 ````
@@ -82,7 +82,7 @@ Then use cmake to build
 ````
 mkdir build && cd build
 cmake -DCMAKE_BUILD_TYPE=Release ..
-cmake --build ..
+cmake --build .
 ````
 Use `CMAKE_BUILD_TYPE=Debug` for a debug build
 


### PR DESCRIPTION
This PR:

- Adds a note about M1 Macs:

```
Undefined symbols for architecture arm64:
  "void GetDefaultMember::handle<unsigned long>(unsigned long const&)", referenced from:
      void reflect_layout<GetMember>(GetMember&, boost::intrusive_ptr<TextLayout> const&) in text.cpp.o
ld: symbol(s) not found for architecture arm64
```
- Fixes instructions for cmake build