### PR TITLE
Script: to_date accepts "now" as an input

### DIFF
--- a/doc/function/to_date.txt
+++ b/doc/function/to_date.txt
@@ -14,6 +14,8 @@ Convert a string value to a [[type:date]].
 --Examples--
 > to_date("2008-12-31 23:59:59")
 > to_date("today midnight")
+> to_date("today noon")
+> to_date("now")
 
 --See also--
 | [[fun:to_string]]	Convert dates to strings

--- a/src/script/functions/basic.cpp
+++ b/src/script/functions/basic.cpp
@@ -216,9 +216,16 @@ SCRIPT_FUNCTION(to_color) {
 
 SCRIPT_FUNCTION(to_date) {
   try {
-    SCRIPT_PARAM_C(wxDateTime, input);
-    SCRIPT_RETURN(input);
-  } catch (const ScriptError& e) {
+    SCRIPT_PARAM_C(String, input);
+    if (input == "now") {
+      SCRIPT_RETURN(wxDateTime::Now());
+    }
+    else {
+      SCRIPT_PARAM_C(wxDateTime, input);
+      SCRIPT_RETURN(input);
+    }
+  }
+  catch (const ScriptError& e) {
     return delay_error(e);
   }
 }


### PR DESCRIPTION
There is currently no way to get the current date and time within an export script (we can get the date by giving "today midnight"/"today noon", but not the time).
This simple change allows us to get the time.