### PR TITLE
Script: to_image accepts a card as an input

### DIFF
--- a/doc/function/to_image.txt
+++ b/doc/function/to_image.txt
@@ -13,6 +13,7 @@ Convert any value to a [[type:image]].
 --Parameters--
 ! Parameter	Type			Description
 | @input@	''any type''		Value to convert to an image
+| @zoom@	[[type:double]] (optional)	A zoom value for the image. Only used when converting cards. This allows you to keep the sharpness of the text at higher resolution.
 
 --Examples--
 >>> to_image("image1.png")  ==  <img src="image1.png" alt='"image1.png"' style="border:1px solid black;vertical-align:middle;margin:1px;" />

--- a/doc/function/to_image.txt
+++ b/doc/function/to_image.txt
@@ -7,7 +7,8 @@ DOC_MSE_VERSION: since 0.3.8
 
 Convert any value to a [[type:image]].
 
-A string is interpreted as a [[type:filename]].
+* A string is interpreted as a [[type:filename]].
+* A [[type:card]] will be converted into an image onto which image operations can be done.
 
 --Parameters--
 ! Parameter	Type			Description

--- a/src/data/format/formats.hpp
+++ b/src/data/format/formats.hpp
@@ -99,7 +99,7 @@ void export_images(const SetP& set, const vector<CardP>& cards,
 void export_image(const SetP& set, const CardP& card, const String& filename);
 
 /// Generate a bitmap image of a card
-Bitmap export_bitmap(const SetP& set, const CardP& card);
+Bitmap export_bitmap(const SetP& set, const CardP& card, double zoom = 1.0);
 
 /// Export a set to Magic Workstation format
 void export_mws(Window* parent, const SetP& set);

--- a/src/gfx/generated_image.cpp
+++ b/src/gfx/generated_image.cpp
@@ -504,3 +504,21 @@ bool ImageValueToImage::operator == (const GeneratedImage& that) const {
   return that2 && filename == that2->filename
                && age      == that2->age;
 }
+
+// ----------------------------------------------------------------------------- : PreGeneratedImage
+
+PreGeneratedImage::PreGeneratedImage(const Image& image)
+  : image(image)
+{}
+PreGeneratedImage::~PreGeneratedImage() {}
+
+Image PreGeneratedImage::generate(const Options& opt) const {
+  if (!image.Ok()) {
+    return Image(max(1, opt.width), max(1, opt.height));
+  }
+  return image;
+}
+bool PreGeneratedImage::operator == (const GeneratedImage& that) const {
+  const PreGeneratedImage* that2 = dynamic_cast<const PreGeneratedImage*>(&that);
+  return that2 && image.IsSameAs(that2->image);
+}

--- a/src/gfx/generated_image.hpp
+++ b/src/gfx/generated_image.hpp
@@ -386,3 +386,17 @@ private:
   Age age; ///< Age the image was last updated
 };
 
+// ----------------------------------------------------------------------------- : PreGeneratedImage
+
+/// Use an image from an ImageValue as an image
+class PreGeneratedImage : public GeneratedImage {
+public:
+  PreGeneratedImage(const Image& image);
+  ~PreGeneratedImage();
+  Image generate(const Options& opt) const override;
+  bool operator == (const GeneratedImage& that) const override;
+  bool local() const override { return true; }
+private:
+  PreGeneratedImage(const PreGeneratedImage&); // copy ctor
+  Image image;
+};

--- a/src/script/functions/image.cpp
+++ b/src/script/functions/image.cpp
@@ -16,6 +16,8 @@
 #include <data/stylesheet.hpp>
 #include <data/symbol.hpp>
 #include <data/field/symbol.hpp>
+#include <data/format/formats.hpp>
+#include <data/export_template.hpp>
 #include <gfx/generated_image.hpp>
 #include <render/symbol/filter.hpp>
 
@@ -24,8 +26,13 @@ void parse_enum(const String&, ImageCombine& out);
 // ----------------------------------------------------------------------------- : Utility
 
 SCRIPT_FUNCTION(to_image) {
-  SCRIPT_PARAM_C(GeneratedImageP, input);
-  return input;
+  SCRIPT_PARAM_C(ScriptValueP, input);
+  ScriptObject<CardP>* card = dynamic_cast<ScriptObject<CardP>*>(input.get());
+  if (card) {
+    Image image = export_bitmap(export_info()->set, card->getValue()).ConvertToImage();
+    return make_intrusive<PreGeneratedImage>(image);
+  }
+  return input->toImage();
 }
 
 // ----------------------------------------------------------------------------- : Image functions

--- a/src/script/functions/image.cpp
+++ b/src/script/functions/image.cpp
@@ -29,7 +29,9 @@ SCRIPT_FUNCTION(to_image) {
   SCRIPT_PARAM_C(ScriptValueP, input);
   ScriptObject<CardP>* card = dynamic_cast<ScriptObject<CardP>*>(input.get());
   if (card) {
-    Image image = export_bitmap(export_info()->set, card->getValue()).ConvertToImage();
+    SCRIPT_OPTIONAL_PARAM_(double, zoom);
+	if (zoom <= 0) zoom = 1; // default
+    Image image = export_bitmap(export_info()->set, card->getValue(), zoom).ConvertToImage();
     return make_intrusive<PreGeneratedImage>(image);
   }
   return input->toImage();

--- a/src/script/value.cpp
+++ b/src/script/value.cpp
@@ -37,7 +37,7 @@ wxDateTime ScriptValue::toDateTime() const {
   throw ScriptErrorConversion(typeName(), _TYPE_("date"));
 }
 GeneratedImageP ScriptValue::toImage() const {
-  throw ScriptErrorConversion(typeName(), _TYPE_("image"   ));
+  throw ScriptErrorConversion(typeName(), _TYPE_("image"));
 }
 String ScriptValue::toCode() const {
   return toString();


### PR DESCRIPTION
Converting a card to an image allows image operations (cropping, rotating, ...) to be done on it in a exporter before writing them to a file.
Can be used for example to split each side of dfc cards into different images.