### PR TITLE
fix content_width/height on higher zoom values

### DIFF
--- a/src/render/value/choice.cpp
+++ b/src/render/value/choice.cpp
@@ -50,8 +50,8 @@ bool prepare_choice_viewer(RotatedDC& dc, ValueViewer& viewer, ChoiceStyle& styl
       img.generateCached(img_options, &style.mask, &combine, &bitmap, &image, &size);
       // store content properties
       if (style.content_width != size.width || style.content_height != size.height) {
-        style.content_width  = size.width;
-        style.content_height = size.height;
+        style.content_width  = size.width / dc.getZoom();
+        style.content_height = size.height / dc.getZoom();
         return true;
       }
     }


### PR DESCRIPTION
When the zoom is not at 1, content_width and content_height end up being pre-multiplied, which can mess up some scripts (for example, the card type line in the Cajun templates)